### PR TITLE
Update README to recommend Git URL dependency install

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,10 @@ script is dumped.
 
 ## Usage summary
 
-1. Install the plugin (copy `pytest_notebook_test` into your project and
-   reference it in a `pytest_plugins` variable in your `conftest.py`, or
-   package it and register via the `[project.entry-points.pytest11]` in
-   your `pyproject.toml`).
+1. Install the plugin by adding a Git URL dependency in your
+   `pyproject.toml` (for example:
+   `pytest-notebook-test @ git+https://github.com/ORG/REPO.git@main`), then
+   install your project as normal.
 2. Run pytest.  Any notebooks discovered will be collected as tests.
 3. Use inline directives to control which cells run and whether
    exceptions are expected.


### PR DESCRIPTION
### Motivation

- Make the recommended installation route explicit and reproducible by recommending a Git URL dependency in `pyproject.toml`.
- Remove the previous guidance about copying the plugin or registering via `pytest_plugins` to reduce confusion about installation options.
- Encourage installing the plugin via the project dependency mechanism to match common Python packaging workflows.

### Description

- Update `README.md` usage summary to replace the old install instructions with a Git URL dependency example in `pyproject.toml`.
- Add the concrete example `pytest-notebook-test @ git+https://github.com/ORG/REPO.git@main` to demonstrate the format.
- Clarify that after adding the dependency you should `install your project as normal` so the plugin is available to pytest.

### Testing

- No automated tests were run because this is a documentation-only change.
- The change does not modify runtime code or test behavior, so the test suite was not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961c99293c8832cbcf964d0f859147d)