### PR TITLE
Fix hookwrapper report handling for notebook tests

### DIFF
--- a/pytest_notebook_test/plugin.py
+++ b/pytest_notebook_test/plugin.py
@@ -453,7 +453,8 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> None:
     code to the report if configured to do so.  The hook is implemented
     as a wrapper using ``yield`` to access the generated report.
     """
-    rep = yield
+    outcome = yield
+    rep = outcome.get_result()
     if isinstance(item, NotebookItem):
         # rep is a TestReport for call and for setup/teardown phases
         item._dump_generated_code(rep)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -48,6 +48,21 @@ def test_run_simple_notebook(pytester: pytest.Pytester) -> None:
     result.assert_outcomes(passed=1)
 
 
+def test_xdist_worksteal_hookwrapper(pytester: pytest.Pytester) -> None:
+    """Run the hookwrapper path under xdist worksteal scheduling.
+
+    Args:
+        pytester: Pytest fixture for running tests in a temporary workspace.
+
+    Example:
+        pytest -k test_xdist_worksteal_hookwrapper
+    """
+    notebooks_dir = Path(__file__).parent / "notebooks"
+    copy_notebook(notebooks_dir / "test_simple.ipynb", pytester.path)
+    result = pytester.runpytest_subprocess("-n", "2", "--dist", "worksteal")
+    result.assert_outcomes(passed=1)
+
+
 def test_default_all_directive(pytester: pytest.Pytester) -> None:
     """Test the ``default-all`` directive.
 


### PR DESCRIPTION
### Motivation
- The hookwrapper implementation in `pytest_runtest_makereport` previously treated the yielded value as a `TestReport` directly which is incorrect when the hook is a wrapper.  
- Under xdist (worksteal) the wrapper path yields an `Outcome` object and the real `TestReport` must be retrieved with `get_result()` to avoid a `Result` vs `TestReport` mismatch.  
- A regression test exercising the xdist worksteal scheduling path is needed to prevent regressions of this hookwrapper behavior.  

### Description
- In `pytest_notebook_test/plugin.py` updated `pytest_runtest_makereport` to use `outcome = yield` and `rep = outcome.get_result()` so the real report object is retrieved.  
- Kept the `NotebookItem` check and continue to pass the real `rep` into `item._dump_generated_code(rep)`.  
- Added `test_xdist_worksteal_hookwrapper` to `tests/test_plugin.py` which copies `tests/notebooks/test_simple.ipynb` and runs `pytester.runpytest_subprocess("-n", "2", "--dist", "worksteal")` asserting `result.assert_outcomes(passed=1)`.  

### Testing
- Attempted to run `pylint pytest_notebook_test/plugin.py tests/test_plugin.py` as required by repository conventions, but it failed because `pylint` is not installed in the environment.  
- No local `pytest` invocation was executed in this session; the added regression test should be exercised by the project CI or by running `pytest -q` locally or in an environment with xdist available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961d684ef24832c89be1be127092587)