### PR TITLE
Document running targeted notebook tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,3 +299,15 @@ Run the tests as usual:
 ```bash
 pytest
 ```
+
+To run just a single notebook or a directory of notebooks, use the
+`--notebook-dir` option (repeatable) alongside `--notebook-glob` when
+needed.  For example:
+
+```bash
+# Run a single notebook by scoping to its directory and globbing the file.
+pytest --notebook-dir tests/notebooks --notebook-glob test_simple.ipynb
+
+# Run every notebook under a specific directory (recursively).
+pytest --notebook-dir tests/notebooks
+```


### PR DESCRIPTION
### Motivation

- Provide guidance for users to run individual notebooks or a set of notebooks without running the entire test suite.
- Clarify how to scope notebook discovery when using the plugin so debugging and development are faster.

### Description

- Updated `README.md` to add a short section showing how to use `--notebook-dir` and `--notebook-glob` to target tests.
- Included two examples demonstrating running a single notebook via `--notebook-dir` + `--notebook-glob` and running all notebooks under a directory with `--notebook-dir`.

### Testing

- No automated tests were run because this is a documentation-only change.
- Existing test suite and CI should be unaffected by this README update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961d6aaa580832c98df16af515ed90f)